### PR TITLE
chore: 개발 환경 MSW 제어

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# API
+VITE_API_BASE_URL=
+
+# MSW
+# Default: enabled in dev. Set to 'false' to disable MSW.
+VITE_USE_MSW=true

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ coverage
 .env
 .env.local
 .env.*
+!.env.example
 .env.development.local
 .env.test.local
 .env.production.local
@@ -54,3 +55,4 @@ tsconfig.tsbuildinfo
 
 # OS
 Thumbs.db
+.docs

--- a/docs/changes/2026-02-25-msw-guard.md
+++ b/docs/changes/2026-02-25-msw-guard.md
@@ -1,0 +1,70 @@
+# 2026-02-25 MSW Guard
+
+## Summary
+
+- Guarded MSW startup to run only in dev.
+- Added an opt-out flag for dev: `VITE_USE_MSW=false`.
+- Rendered app immediately in production.
+- Added a dev-only warning when `VITE_API_BASE_URL` is missing.
+
+## Before
+
+```tsx
+import '@/styles/index.css';
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { Providers } from './app/providers';
+import { startMockServer } from './mocks/browser';
+
+const root = createRoot(document.getElementById('root')!);
+
+startMockServer().then(() => {
+  root.render(
+    <React.StrictMode>
+      <Providers />
+    </React.StrictMode>
+  );
+});
+```
+
+## After
+
+```tsx
+import '@/styles/index.css';
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { Providers } from './app/providers';
+import { startMockServer } from './mocks/browser';
+
+const root = createRoot(document.getElementById('root')!);
+
+const bootstrap = () => {
+  root.render(
+    <React.StrictMode>
+      <Providers />
+    </React.StrictMode>
+  );
+};
+
+const isDev = import.meta.env.DEV;
+const useMsw = isDev && import.meta.env.VITE_USE_MSW !== 'false';
+
+if (isDev && !import.meta.env.VITE_API_BASE_URL) {
+  console.warn('[Swap-Go] VITE_API_BASE_URL is not set.');
+}
+
+if (useMsw) {
+  startMockServer().then(bootstrap);
+} else {
+  bootstrap();
+}
+```
+
+## Usage Notes
+
+- Default dev behavior: MSW enabled.
+- To disable MSW in dev: set `VITE_USE_MSW=false` in your env.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,30 +8,23 @@ import { startMockServer } from './mocks/browser';
 
 const root = createRoot(document.getElementById('root')!);
 
-startMockServer().then(() => {
+const bootstrap = () => {
   root.render(
     <React.StrictMode>
       <Providers />
     </React.StrictMode>
   );
-});
+};
 
-// ⭐ 자동 로그인 함수
-// async function initAuth() {
-//   try {
-//     console.log('🔄 자동 로그인 시도 중...');
+const isDev = import.meta.env.DEV;
+const useMsw = isDev && import.meta.env.VITE_USE_MSW !== 'false';
 
-//     // refreshToken으로 accessToken 재발급
-//     const { accessToken } = await authService.refreshToken();
-//     // → POST /auth/refresh
-//     // → Cookie: refreshToken=abc123... (자동 첨부)
+if (isDev && !import.meta.env.VITE_API_BASE_URL) {
+  console.warn('[Swap-Go] VITE_API_BASE_URL is not set.');
+}
 
-//     // 새 토큰 저장
-//     tokenManager.setAccessToken(accessToken);
-
-//     console.log('✅ 자동 로그인 성공!');
-//   } catch (error) {
-//     console.log('❌ 자동 로그인 실패 (refreshToken 없거나 만료)');
-//     tokenManager.clearAccessToken();
-//   }
-// }
+if (useMsw) {
+  startMockServer().then(bootstrap);
+} else {
+  bootstrap();
+}


### PR DESCRIPTION
## 요약
- MSW 시작을 개발 환경에서만 수행
- 개발 환경에서도 VITE_USE_MSW=false로 MSW 비활성화 가능
- .env.example에 MSW 플래그 추가
