### PR TITLE
fix: 인증 초기화 안정화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ coverage
 .env.development.local
 .env.test.local
 .env.production.local
+
+# local notes (not for GitHub)
+docs/private/
 *.local
 
 # TypeScript

--- a/src/features/auth/hooks/useAuthInit.ts
+++ b/src/features/auth/hooks/useAuthInit.ts
@@ -23,11 +23,14 @@ export const useAuthInit = () => {
         }
 
         tokenManager.setAccessToken(accessToken);
+        const user = await authService.getMe();
+        queryClient.setQueryData(['auth', 'user'], user);
         console.log('✅ 자동 로그인 성공');
       } catch (error) {
         console.log('❌ 자동 로그인 실패 (로그아웃 상태)');
         console.error(error);
         tokenManager.clearAccessToken();
+        queryClient.setQueryData(['auth', 'user'], null);
       } finally {
         setIsInitialized(true);
       }

--- a/src/shared/utils/axios.ts
+++ b/src/shared/utils/axios.ts
@@ -113,6 +113,7 @@ api.interceptors.response.use(
       } catch (refreshError) {
         processQueue(refreshError as Error, null);
         tokenManager.clearAccessToken();
+        window.dispatchEvent(new Event('auth-expired'));
 
         return Promise.reject(
           refreshError instanceof Error


### PR DESCRIPTION
## 요약
- 리프레시 실패 시 인증 만료 이벤트 전파
- 인증 초기화 시 사용자 캐시 선로딩으로 초기 상태 안정화

## 변경 파일
- src/shared/utils/axios.ts
- src/features/auth/hooks/useAuthInit.ts
