### PR TITLE
에러 핸들링 관련 리팩토링

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-intersection-observer": "^10.0.0",
     "react-router-dom": "^7.9.4",
     "use-places-autocomplete": "^4.0.1",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       zod:
         specifier: ^4.1.12
         version: 4.1.13
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@19.2.7)(react@19.2.0)
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.1.0
@@ -3178,6 +3181,24 @@ packages:
 
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -6398,3 +6419,8 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   zod@4.1.13: {}
+
+  zustand@5.0.12(@types/react@19.2.7)(react@19.2.0):
+    optionalDependencies:
+      '@types/react': 19.2.7
+      react: 19.2.0

--- a/src/app/QueryClientBoundary.tsx
+++ b/src/app/QueryClientBoundary.tsx
@@ -1,0 +1,8 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+
+import { queryClient } from './queryClient';
+
+export const QueryClientBoundary = ({ children }: { children: ReactNode }) => {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+};

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,4 +1,3 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { BrowserRouter, useRoutes } from 'react-router-dom';
@@ -6,38 +5,20 @@ import { BrowserRouter, useRoutes } from 'react-router-dom';
 import { useAuthInit } from '@/features/auth/hooks/useAuthInit';
 import { LoginModal } from '@/features/auth/ui';
 import { ModalProvider } from '@/shared/context/ModalProvider';
-import { ErrorBoundary } from '@/shared/ui';
+import { QueryErrorBoundary, ToastSubscriber } from '@/shared/ui';
 
+import { QueryClientBoundary } from './QueryClientBoundary';
 import { routes } from './router/routes';
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-      staleTime: 5 * 60 * 1000, // 5분
-      refetchOnMount: true,
-      refetchOnReconnect: true,
-      refetchOnWindowFocus: true,
-    },
-    mutations: {
-      retry: false,
-    },
-  },
-});
-
-// App은 라우팅만 하는 역할
 function AppRoutes() {
   const element = useRoutes(routes);
 
   return <Suspense fallback={<div>Loading...</div>}>{element}</Suspense>;
 }
 
-// 앱 초기화 + 라우팅
 function AppContent() {
-  // 앱 초기화 (Access Token 복구)
   const { isInitialized } = useAuthInit();
 
-  // 초기화 전에는 로딩 표시
   if (!isInitialized) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -49,7 +30,6 @@ function AppContent() {
     );
   }
 
-  // 초기화 완료 후 라우팅
   return (
     <>
       <AppRoutes />
@@ -58,18 +38,18 @@ function AppContent() {
   );
 }
 
-// 앱 전체에 필요한 providers 집합
 export function Providers() {
   return (
     <BrowserRouter>
-      <QueryClientProvider client={queryClient}>
+      <QueryClientBoundary>
         <ModalProvider>
+          <ToastSubscriber />
           <Toaster />
-          <ErrorBoundary>
+          <QueryErrorBoundary>
             <AppContent />
-          </ErrorBoundary>
+          </QueryErrorBoundary>
         </ModalProvider>
-      </QueryClientProvider>
+      </QueryClientBoundary>
     </BrowserRouter>
   );
 }

--- a/src/app/queryClient.ts
+++ b/src/app/queryClient.ts
@@ -1,0 +1,25 @@
+import { MutationCache, QueryClient } from '@tanstack/react-query';
+
+import { useErrorStore } from '@/shared/store/errorStore';
+import { handleAPIError } from '@/shared/utils';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 5 * 60 * 1000,
+      refetchOnMount: true,
+      refetchOnReconnect: true,
+      refetchOnWindowFocus: true,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+  mutationCache: new MutationCache({
+    onError: (error) => {
+      const message = handleAPIError(error);
+      useErrorStore.getState().setError(message);
+    },
+  }),
+});

--- a/src/app/router/routes.tsx
+++ b/src/app/router/routes.tsx
@@ -3,7 +3,7 @@ import { RouteObject } from 'react-router-dom';
 
 import SignupPage from '@/pages/SignupPage';
 import { ProtectedRoute } from '@/shared/router/ProtectedRoute';
-import { ErrorBoundary } from '@/shared/ui';
+import { ErrorBoundary, QueryErrorBoundary } from '@/shared/ui';
 import PageLayout from '@/shared/ui/PageLayout';
 
 import ListingCreatePage from '../../pages/ListingCreatePage';
@@ -19,7 +19,14 @@ export const routes: RouteObject[] = [
     element: <PageLayout />,
     children: [
       { path: ROUTE_PATH.HOME, element: <HomePage /> },
-      { path: ROUTE_PATH.SIGNUP, element: <SignupPage /> },
+      {
+        path: ROUTE_PATH.SIGNUP,
+        element: (
+          <ErrorBoundary>
+            <SignupPage />
+          </ErrorBoundary>
+        ),
+      },
       {
         path: ROUTE_PATH.RESALE,
         element: (
@@ -39,14 +46,23 @@ export const routes: RouteObject[] = [
       {
         path: ROUTE_PATH.PRODUCT_DETAIL,
         element: (
-          <ErrorBoundary>
+          <QueryErrorBoundary>
             <ProductDetailPage />
-          </ErrorBoundary>
+          </QueryErrorBoundary>
         ),
       },
       {
         element: <ProtectedRoute />,
-        children: [{ path: ROUTE_PATH.LISTING_NEW, element: <ListingCreatePage /> }],
+        children: [
+          {
+            path: ROUTE_PATH.LISTING_NEW,
+            element: (
+              <ErrorBoundary>
+                <ListingCreatePage />
+              </ErrorBoundary>
+            ),
+          },
+        ],
       },
     ],
   },

--- a/src/features/auth/hooks/signup/useEmailMutation.ts
+++ b/src/features/auth/hooks/signup/useEmailMutation.ts
@@ -1,8 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
 import toast from 'react-hot-toast';
-
-import { handleAPIError } from '@/shared/utils/errorHandler';
 
 import { sendEmailVerificationCode, verifyEmailCode } from '../../api/email.api';
 import {
@@ -18,9 +15,6 @@ export const useSendEmailCodeMutation = () => {
     onSuccess: (data: SendEmailCodeResponse) => {
       toast.success(data?.message ?? '인증번호가 발송되었습니다.\n이메일을 확인해주세요.');
     },
-    onError: (error: AxiosError) => {
-      toast.error(handleAPIError(error));
-    },
   });
 };
 
@@ -29,9 +23,6 @@ export const useVerifyEmailCode = () => {
     mutationFn: (data: VerifyEmailCodeRequest) => verifyEmailCode(data),
     onSuccess: (data: VerifyEmailCodeResponse) => {
       toast.success(data?.message ?? '이메일 인증이 완료되었습니다.');
-    },
-    onError: (error: AxiosError) => {
-      toast.error(handleAPIError(error));
     },
   });
 };

--- a/src/features/auth/hooks/signup/useSignupMutation.ts
+++ b/src/features/auth/hooks/signup/useSignupMutation.ts
@@ -2,8 +2,6 @@ import { useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
-import { handleAPIError } from '@/shared/utils';
-
 import { authService } from '../../api';
 import { SignupResponse } from '../../types';
 
@@ -14,9 +12,6 @@ export const useSignupMutation = () => {
     onSuccess: (data: SignupResponse) => {
       toast.success(data?.message ?? '회원가입이 완료되었습니다.');
       navigate('/');
-    },
-    onError: (error) => {
-      toast.error(handleAPIError(error));
     },
   });
 };

--- a/src/features/listing/hooks/useCreateListingMutation.ts
+++ b/src/features/listing/hooks/useCreateListingMutation.ts
@@ -2,8 +2,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import toast from 'react-hot-toast';
 
-import { handleAPIError } from '@/shared/utils';
-
 import { productKeys } from '../../product/queryKeys';
 import { createListing } from '../api/listing.api';
 import { CreateListingRequest, ListingResponse } from '../types/listing.types';
@@ -21,10 +19,6 @@ export const useCreateListingMutation = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: productKeys.lists() });
       toast.success('게시물이 등록되었습니다.');
-    },
-    onError: (error) => {
-      const message = handleAPIError(error);
-      toast.error(message);
     },
   });
 };

--- a/src/features/listing/hooks/useListingMutation.ts
+++ b/src/features/listing/hooks/useListingMutation.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import toast from 'react-hot-toast';
 
-import { handleAPIError } from '../../../shared/utils';
 import { productKeys } from '../../product/queryKeys';
 import { deleteListing, updateListing } from '../api/listing.api';
 import { ListingRequest, ListingResponse } from '../types/listing.types';
@@ -30,9 +28,6 @@ export const useUpdateListing = () => {
       queryClient.invalidateQueries({ queryKey: productKeys.lists() });
       queryClient.invalidateQueries({ queryKey: productKeys.detail(data.itemType, itemId) });
     },
-    onError: (error) => {
-      toast.error(handleAPIError(error));
-    },
   });
 };
 
@@ -44,9 +39,6 @@ export const useDeleteListing = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: productKeys.lists() });
       queryClient.invalidateQueries({ queryKey: productKeys.details() });
-    },
-    onError: (error) => {
-      toast.error(handleAPIError(error));
     },
   });
 };

--- a/src/features/product/hooks/useProductDetailPage.ts
+++ b/src/features/product/hooks/useProductDetailPage.ts
@@ -23,6 +23,7 @@ export const useProductDetailPage = () => {
       return Promise.reject(new Error('잘못된 접근입니다.'));
     },
     enabled: isValid,
+    throwOnError: true,
   });
 
   const { resaleItems, rentalItems } = useMemo(() => {

--- a/src/features/trade/hooks/useRequestTrade.ts
+++ b/src/features/trade/hooks/useRequestTrade.ts
@@ -1,8 +1,5 @@
 import { useMutation, UseMutationResult } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import toast from 'react-hot-toast';
-
-import { handleAPIError } from '@/shared/utils';
 
 import { requestRentalTrade, requestResaleTrade } from '../api/trade.api';
 import {
@@ -19,7 +16,6 @@ export const useRequestResaleTrade = (): UseMutationResult<
 > => {
   return useMutation({
     mutationFn: (itemId) => requestResaleTrade(itemId),
-    onError: (err) => toast.error(handleAPIError(err)),
   });
 };
 
@@ -30,6 +26,5 @@ export const useRequestRentalTrade = (): UseMutationResult<
 > => {
   return useMutation({
     mutationFn: (data) => requestRentalTrade(data),
-    onError: (err) => toast.error(handleAPIError(err)),
   });
 };

--- a/src/features/trade/ui/RentalRequestModal.tsx
+++ b/src/features/trade/ui/RentalRequestModal.tsx
@@ -31,9 +31,6 @@ export const RentalRequestModal = ({ isOpen, onClose, itemId }: RentalRequestMod
           toast.success('거래 요청을 보냈어요.');
           onClose();
         },
-        onError: () => {
-          toast.error('요청 전송에 실패했어요. 잠시 후 다시 시도해주세요.');
-        },
       }
     );
   };

--- a/src/features/trade/ui/TradeRequestButton.tsx
+++ b/src/features/trade/ui/TradeRequestButton.tsx
@@ -28,9 +28,6 @@ export const TradeRequestButton = ({ type, itemId }: Props) => {
           toast.success('거래 요청을 보냈어요.');
           closeModal();
         },
-        onError: () => {
-          toast.error('요청 전송에 실패했어요. 잠시 후 다시 시도해주세요.');
-        },
       }
     );
   };

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -1,19 +1,26 @@
 import { Navigate } from 'react-router-dom';
 
 import { useProductDetailPage } from '../features/product/hooks/useProductDetailPage';
-import { ProductCarousel } from '../features/product/ui/ProductCarousel'; // ✨ Carousel 직접 import
+import { ProductCarousel } from '../features/product/ui/ProductCarousel';
 import { ProductDetailCard } from '../features/product/ui/ProductDetailCard';
 
 const ProductDetailPage = () => {
-  const { type, data, resaleItems, rentalItems, isLoading, isError } = useProductDetailPage();
+  const { type, data, resaleItems, rentalItems, isLoading } = useProductDetailPage();
 
-  if (isLoading) return <div>로딩 중...</div>;
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="animate-spin rounded-full h-12 w-12 border-4 border-gray-200 border-t-primary-500" />
+      </div>
+    );
+  }
 
   const isValidType = type === 'resale' || type === 'rental';
 
-  if (isError || !data || !type || !isValidType) {
+  if (!data || !type || !isValidType) {
     return <Navigate to="/" replace />;
   }
+
   const sellerName = data.seller.username;
 
   return (

--- a/src/shared/store/errorStore.ts
+++ b/src/shared/store/errorStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface ErrorState {
+  errorMessage: string | null;
+  setError: (message: string) => void;
+  clearError: () => void;
+}
+
+export const useErrorStore = create<ErrorState>((set) => ({
+  errorMessage: null,
+  setError: (message) => set({ errorMessage: message }),
+  clearError: () => set({ errorMessage: null }),
+}));

--- a/src/shared/ui/ErrorBoundary.tsx
+++ b/src/shared/ui/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { captureException } from '@/shared/utils/sentry';
 interface Props {
   children: ReactNode;
   fallback?: ReactNode;
+  onReset?: () => void;
 }
 
 interface State {
@@ -23,6 +24,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   handleReset = () => {
+    this.props.onReset?.();
     this.setState({ hasError: false });
   };
 

--- a/src/shared/ui/QueryErrorBoundary.tsx
+++ b/src/shared/ui/QueryErrorBoundary.tsx
@@ -1,0 +1,9 @@
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+
+import { ErrorBoundary } from './ErrorBoundary';
+
+export const QueryErrorBoundary = ({ children }: { children: ReactNode }) => {
+  const { reset } = useQueryErrorResetBoundary();
+  return <ErrorBoundary onReset={reset}>{children}</ErrorBoundary>;
+};

--- a/src/shared/ui/ToastSubscriber.tsx
+++ b/src/shared/ui/ToastSubscriber.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import toast from 'react-hot-toast';
+
+import { useErrorStore } from '../store/errorStore';
+
+export const ToastSubscriber = () => {
+  const errorMessage = useErrorStore((s) => s.errorMessage);
+  const clearError = useErrorStore((s) => s.clearError);
+
+  useEffect(() => {
+    if (errorMessage) {
+      toast.error(errorMessage);
+      clearError();
+    }
+  }, [errorMessage, clearError]);
+
+  return null;
+};

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -5,3 +5,5 @@ export * from './Modal';
 export * from './ModalPortal';
 export * from './PageLayout';
 export * from './ProtectedNavButton';
+export * from './QueryErrorBoundary';
+export * from './ToastSubscriber';


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #33 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

- [x] zustand 로 에러 상태 전역 관리
- [x] 에러 상태를 api - hook - ui 레이어마다 처리
- [x] mutation 관련 (조회 api 제외) 에러는 토스트 ui 띄워서 일관적 처리
- [x] useQuery 관련 (조회api) 에러는 에러 바운더리 컴포넌트에서 fallback ui 보여주도록 처리
- [x] fallback ui 에서 쿼리 재시도 CTA 추가할 수 있도록 QueryErrorBoundary 도 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ⏰ 현재 버그

## ✏ Git Close

> close #33 